### PR TITLE
새로운 루트 기록 - 루트 기록 기능

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,4 +55,7 @@ dependencies {
 
     // lifecycle
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
+
+    // location
+    implementation 'com.google.android.gms:play-services-location:19.0.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,4 +52,7 @@ dependencies {
     // navigation
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+
+    // lifecycle
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.4.1"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.TodayRoute">
+
+        <meta-data
+            android:name="com.naver.maps.map.CLIENT_ID"
+            android:value="4cbxzd2ci5"/>
+
         <activity
             android:name="com.maru.todayroute.MainActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.maru.todayroute">
 
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -5,14 +5,45 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.maru.todayroute.R
+import com.maru.todayroute.databinding.FragmentHomeBinding
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.OnMapReadyCallback
 
-class HomeFragment : Fragment() {
+class HomeFragment : Fragment(), OnMapReadyCallback {
+
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return inflater.inflate(R.layout.fragment_home, container, false)
+        _binding = FragmentHomeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycle.addObserver(MapViewLifecycleObserver(binding.mvMap, savedInstanceState))
+        binding.mvMap.getMapAsync(this)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        binding.mvMap.onSaveInstanceState(outState)
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        binding.mvMap.onLowMemory()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    override fun onMapReady(p0: NaverMap) {
+
     }
 }

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -15,6 +15,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.maru.todayroute.databinding.FragmentHomeBinding
 import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraAnimation
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
@@ -58,6 +59,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 } else {
                     isRecording = true
                     this.text = "루트 기록 종료"
+                    getLastLocation()
                     recordStartTime = System.currentTimeMillis()
                 }
             }
@@ -111,8 +113,12 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 currentLocation.first,
                 currentLocation.second
             )
-        )
-        naverMap.moveCamera(cameraUpdate)
+        ).animate(CameraAnimation.Easing)
+        val zoomLevel = CameraUpdate.zoomTo(16.0)
+        naverMap.run {
+            moveCamera(zoomLevel)
+            moveCamera(cameraUpdate)
+        }
     }
 
     private fun hasNotLocationPermission(): Boolean {

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -28,6 +28,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     private lateinit var naverMap: NaverMap
     private lateinit var currentLocation: Pair<Double, Double>
 
+    private var isRecording = false
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -42,6 +44,21 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         binding.mvMap.getMapAsync(this)
         if (hasNotLocationPermission()) {
             requestLocationPermission()
+        }
+        setButtonClickListener()
+    }
+
+    private fun setButtonClickListener() {
+        with (binding.btStartRecordRoute) {
+            setOnClickListener {
+                if (isRecording) {
+                    isRecording = false
+                    this.text = "루트 기록 시작"
+                } else {
+                    isRecording = true
+                    this.text = "루트 기록 종료"
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -7,6 +7,7 @@ import android.graphics.Color
 import android.location.Location
 import android.os.Bundle
 import android.os.Looper
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -21,6 +22,7 @@ import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.PathOverlay
+import kotlin.math.roundToInt
 
 class HomeFragment : Fragment(), OnMapReadyCallback {
 
@@ -60,18 +62,31 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(locationResult: LocationResult) {
                 for (location in locationResult.locations){
-                    geoCoordList.add(LatLng(location.latitude, location.longitude))
-                    currentLocation = Pair(location.latitude, location.longitude)
-                    showOverlayOnCurrentLocation(currentLocation)
-                    if (2 <= geoCoordList.size) {
-                        path.coords = geoCoordList
-                        if (path.map == null) {
-                            path.map = naverMap
+                    Log.d("location", "${location.latitude} ${location.longitude}")
+
+                    if (!isSameLocation(location.latitude, location.longitude)) {
+                        geoCoordList.add(LatLng(location.latitude, location.longitude))
+                        currentLocation = Pair(location.latitude, location.longitude)
+                        showOverlayOnCurrentLocation(currentLocation)
+                        if (2 <= geoCoordList.size) {
+                            path.coords = geoCoordList
+                            if (path.map == null) {
+                                path.map = naverMap
+                            }
                         }
                     }
                 }
             }
         }
+    }
+
+    private fun isSameLocation(newLatitude: Double, newLongitude: Double): Boolean {
+        val preLatitude = (currentLocation.first * 10000).roundToInt()
+        val preLongitude = (currentLocation.second * 10000).roundToInt()
+        val targetLatitude = (newLatitude * 10000).roundToInt()
+        val targetLongitude = (newLongitude * 10000).roundToInt()
+
+        return preLatitude == targetLatitude && preLongitude == targetLongitude
     }
 
     @SuppressLint("MissingPermission")
@@ -206,9 +221,5 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 Manifest.permission.ACCESS_COARSE_LOCATION
             )
         )
-    }
-
-    companion object {
-        const val REQUESTING_LOCATION_UPDATES_KEY = "requesting_location_updates"
     }
 }

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -1,10 +1,14 @@
 package com.maru.todayroute.home
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
 import com.maru.todayroute.databinding.FragmentHomeBinding
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.OnMapReadyCallback
@@ -26,6 +30,9 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
         super.onViewCreated(view, savedInstanceState)
         viewLifecycleOwner.lifecycle.addObserver(MapViewLifecycleObserver(binding.mvMap, savedInstanceState))
         binding.mvMap.getMapAsync(this)
+        if (hasNotLocationPermission()) {
+            requestLocationPermission()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -45,5 +52,39 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
 
     override fun onMapReady(p0: NaverMap) {
 
+    }
+
+    private fun hasNotLocationPermission(): Boolean {
+        return ActivityCompat.checkSelfPermission(
+            requireContext(),
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) != PackageManager.PERMISSION_GRANTED
+                || ActivityCompat.checkSelfPermission(
+            requireContext(),
+            Manifest.permission.ACCESS_COARSE_LOCATION
+        ) != PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestLocationPermission() {
+        val locationPermissionRequest = registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions()
+        ) { permissions ->
+            when {
+                permissions[Manifest.permission.ACCESS_FINE_LOCATION] ?: false
+                        || permissions[Manifest.permission.ACCESS_COARSE_LOCATION] ?: false
+                -> {
+                }
+                else -> {
+
+                }
+            }
+        }
+
+        locationPermissionRequest.launch(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
     }
 }

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -29,6 +29,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     private lateinit var currentLocation: Pair<Double, Double>
 
     private var isRecording = false
+    private var recordStartTime = -1L
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -57,6 +58,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 } else {
                     isRecording = true
                     this.text = "루트 기록 종료"
+                    recordStartTime = System.currentTimeMillis()
                 }
             }
         }

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -3,6 +3,7 @@ package com.maru.todayroute.home
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.location.Location
 import android.os.Bundle
 import android.os.Looper
@@ -64,7 +65,9 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     showOverlayOnCurrentLocation(currentLocation)
                     if (2 <= geoCoordList.size) {
                         path.coords = geoCoordList
-                        path.map = naverMap
+                        if (path.map == null) {
+                            path.map = naverMap
+                        }
                     }
                 }
             }
@@ -74,6 +77,8 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     @SuppressLint("MissingPermission")
     private fun startLocationUpdates() {
         path = PathOverlay()
+        path.color = Color.YELLOW
+        path.width = 20
         geoCoordList.add(LatLng(currentLocation.first, currentLocation.second))
 
         initLocationCallback()
@@ -106,6 +111,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     this.text = "루트 기록 종료"
                     getLastLocation()
                     startLocationUpdates()
+                    setMapCameraZoom(16.0)
                     recordStartTime = System.currentTimeMillis()
                 }
             }
@@ -160,11 +166,11 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 currentLocation.second
             )
         ).animate(CameraAnimation.Easing)
-        val zoomLevel = CameraUpdate.zoomTo(16.0)
-        naverMap.run {
-            moveCamera(zoomLevel)
-            moveCamera(cameraUpdate)
-        }
+        naverMap.moveCamera(cameraUpdate)
+    }
+
+    private fun setMapCameraZoom(level: Double) {
+        naverMap.moveCamera(CameraUpdate.zoomTo(level))
     }
 
     private fun hasNotLocationPermission(): Boolean {

--- a/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
+++ b/app/src/main/java/com/maru/todayroute/home/HomeFragment.kt
@@ -115,7 +115,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
     }
 
     private fun setButtonClickListener() {
-        with (binding.btStartRecordRoute) {
+        with (binding.btnStartRecordRoute) {
             setOnClickListener {
                 if (isRecording) {
                     isRecording = false
@@ -126,10 +126,13 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                     this.text = "루트 기록 종료"
                     getLastLocation()
                     startLocationUpdates()
-                    setMapCameraZoom(16.0)
                     recordStartTime = System.currentTimeMillis()
                 }
             }
+        }
+
+        binding.btnCurrentLocation.setOnClickListener {
+            moveMapCameraToCurrentLocation(currentLocation)
         }
     }
 
@@ -162,6 +165,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 currentLocation = Pair(location.latitude, location.longitude)
 
                 showOverlayOnCurrentLocation(currentLocation)
+                moveMapCameraToCurrentLocation(currentLocation)
             }
         }
     }
@@ -171,7 +175,6 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
             isVisible =  true
             position = LatLng(currentLocation.first, currentLocation.second)
         }
-        moveMapCameraToCurrentLocation(currentLocation)
     }
 
     private fun moveMapCameraToCurrentLocation(currentLocation: Pair<Double, Double>) {
@@ -181,6 +184,7 @@ class HomeFragment : Fragment(), OnMapReadyCallback {
                 currentLocation.second
             )
         ).animate(CameraAnimation.Easing)
+        setMapCameraZoom(16.0)
         naverMap.moveCamera(cameraUpdate)
     }
 

--- a/app/src/main/java/com/maru/todayroute/home/MapViewLifecycleObserver.kt
+++ b/app/src/main/java/com/maru/todayroute/home/MapViewLifecycleObserver.kt
@@ -1,0 +1,40 @@
+package com.maru.todayroute.home
+
+import android.os.Bundle
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.naver.maps.map.MapView
+
+class MapViewLifecycleObserver(private val mapView: MapView, private val savedInstanceState: Bundle?) :
+    DefaultLifecycleObserver {
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        mapView.onStart()
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        mapView.onResume()
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        mapView.onCreate(savedInstanceState)
+    }
+
+    override fun onPause(owner: LifecycleOwner) {
+        super.onPause(owner)
+        mapView.onPause()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        mapView.onStop()
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        super.onDestroy(owner)
+        mapView.onDestroy()
+    }
+}

--- a/app/src/main/res/drawable/bg_current_location_white.xml
+++ b/app/src/main/res/drawable/bg_current_location_white.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners
+        android:radius="5dp"/>
+    <solid
+        android:color="@color/white"/>
+    <stroke
+        android:color="#D6D6D6"
+        android:width="1dp"/>
+</shape>

--- a/app/src/main/res/drawable/ic_baseline_my_location_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_my_location_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#7295B9"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11c-0.46,-4.17 -3.77,-7.48 -7.94,-7.94L13,1h-2v2.06C6.83,3.52 3.52,6.83 3.06,11L1,11v2h2.06c0.46,4.17 3.77,7.48 7.94,7.94L11,23h2v-2.06c4.17,-0.46 7.48,-3.77 7.94,-7.94L23,13v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -14,7 +14,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/mv_map"
         >
-        
+
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/tb_home"
             android:layout_width="match_parent"
@@ -31,8 +31,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/btn_current_location"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:padding="8dp"
+        android:layout_marginBottom="12dp"
+        android:layout_marginEnd="12dp"
+        android:src="@drawable/ic_baseline_my_location_24"
+        android:background="@drawable/bg_current_location_white"
+        android:elevation="10dp"
+        app:layout_constraintEnd_toEndOf="@id/mv_map"
+        app:layout_constraintBottom_toBottomOf="@id/mv_map" />
+
     <androidx.appcompat.widget.AppCompatButton
-        android:id="@+id/bt_start_record_route"
+        android:id="@+id/btn_start_record_route"
         android:layout_width="200dp"
         android:layout_height="64dp"
         android:text="루트 기록 시작"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -32,6 +32,7 @@
         app:layout_constraintEnd_toEndOf="parent"/>
 
     <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/bt_start_record_route"
         android:layout_width="200dp"
         android:layout_height="64dp"
         android:text="루트 기록 시작"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,6 +12,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/mv_map"
         >
         
         <androidx.appcompat.widget.Toolbar
@@ -21,5 +22,25 @@
             app:title="오늘의 길"/>
 
     </com.google.android.material.appbar.AppBarLayout>
+
+    <com.naver.maps.map.MapView
+        android:id="@+id/mv_map"
+        android:layout_width="match_parent"
+        android:layout_height="556dp"
+        app:layout_constraintTop_toBottomOf="@id/ab_home"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:layout_width="200dp"
+        android:layout_height="64dp"
+        android:text="루트 기록 시작"
+        android:textSize="20sp"
+        android:textColor="#ffffff"
+        android:backgroundTint="#7295B9"
+        app:layout_constraintTop_toBottomOf="@id/mv_map"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,6 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/ab_home"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="#ffffffff"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        >
+        
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/tb_home"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="오늘의 길"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 📍 이슈 
- closes #4 
## 🛠 작업사항
- [x]  사용자의 위치가 변할 때마다 좌표들을 저장한다.
- [x] 기록한 사용자의 위치들을 선으로 연결하여 지도에 보여준다.
- [x] 현재 위치 중심으로 맵 카메라를 옮길 수 있는 버튼을 추가

## 📋 참고
[맵에 이동 경로 표시하기1](https://developer.android.com/training/location/request-updates?hl=ko)
[맵에 이동 경로 표시하기2](https://dev-daddy.tistory.com/3)
[맵에 이동 경로 표시하기3](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest.html?hl=ko)
[맵에 이동 경로 표시하기4](https://navermaps.github.io/android-map-sdk/guide-ko/5-7.html)
## 📸 스크린샷
<img width="200" alt="image" src="https://user-images.githubusercontent.com/87361140/167811073-a6545533-51d3-49e1-b28a-4d35522baed7.png">

https://user-images.githubusercontent.com/87361140/167811772-f5b7e50d-9f9c-4d83-a144-1a7fc8b6caa4.mov

## ‼️ 이슈
- 실제 단말기로 루트 기록을 수행했더니 나는 가만히 있는데 gps가 좌표를 미세하게 계속 다르게 잡아서 불필요한 선들이 마구 생겼다. 그래서 로그를 찍어보니까 
<img width="200" alt="image" src="https://user-images.githubusercontent.com/87361140/167812787-c3d99ce9-3822-43f3-8e31-872bd419d102.png">
<img width="1414" alt="스크린샷 2022-05-11 오후 3 55 28" src="https://user-images.githubusercontent.com/87361140/167812182-0fa675dd-35e5-4f39-a355-fe8a6660a91a.png">
소숫점 밑 네번째짜리까지 같으면 같은 위치인 걸로 봐도 무방할 거 같아서, 소숫점 밑 다섯번째자리에서 반올림했을 때 값이 이전과 같으면 같은 위치라는 조건을 두고 PathOverlay를 그리기 전에 같은 위치인지 확인하는 작업을 추가해서 이런 버그를 해결했다.
근데 아직 위치 기록하는 로직이 마음에 쏙 들진 않아서 추후에 다시 보고 수정해야할 것 같다!
